### PR TITLE
Add Open Warp scaffold

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["crates/terminal-core", "crates/llm-client", "crates/plugin-sdk"]
+resolver = "2"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Open Warp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/OPEN_WARP.md
+++ b/OPEN_WARP.md
@@ -1,0 +1,13 @@
+# Open Warp
+
+This repository contains the early scaffolding for **Open Warp**, an MIT licensed terminal with optional AI assistance. The project is organized as a Cargo workspace with multiple crates and a Tauri application.
+
+## Workspace Layout
+
+- `crates/terminal-core` – cross-platform PTY wrapper and block model.
+- `crates/llm-client` – asynchronous HTTP client for various LLM providers.
+- `crates/plugin-sdk` – WASM based plugin API.
+- `app` – Tauri + React front-end (to be implemented).
+- `docs` – Documentation built with MkDocs or similar.
+
+Run `cargo test --workspace` to verify the Rust crates build correctly.

--- a/crates/llm-client/Cargo.toml
+++ b/crates/llm-client/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "llm-client"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+anyhow = "1"

--- a/crates/llm-client/src/lib.rs
+++ b/crates/llm-client/src/lib.rs
@@ -1,0 +1,38 @@
+#![deny(clippy::all)]
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct CompletionRequest {
+    pub prompt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CompletionResponse {
+    pub content: String,
+}
+
+pub struct LlmClient {
+    base_url: String,
+    api_key: Option<String>,
+}
+
+impl LlmClient {
+    pub fn new(base_url: impl Into<String>, api_key: Option<String>) -> Self {
+        Self { base_url: base_url.into(), api_key }
+    }
+
+    pub async fn complete(&self, req: CompletionRequest) -> Result<CompletionResponse> {
+        let client = reqwest::Client::new();
+        let mut builder = client.post(format!("{}/v1/completions", self.base_url))
+            .json(&req);
+        if let Some(key) = &self.api_key {
+            builder = builder.bearer_auth(key);
+        }
+        let resp = builder.send().await?.json::<CompletionResponse>().await?;
+        Ok(resp)
+    }
+}

--- a/crates/llm-client/tests/client.rs
+++ b/crates/llm-client/tests/client.rs
@@ -1,0 +1,10 @@
+use llm_client::LlmClient;
+use llm_client::CompletionRequest;
+
+#[tokio::test]
+async fn construct_client() {
+    let client = LlmClient::new("http://localhost:11434", None);
+    let req = CompletionRequest { prompt: "hello".into(), model: None };
+    // We only check that the request building doesn't fail up to sending.
+    let _ = client.complete(req).await.err();
+}

--- a/crates/plugin-sdk/Cargo.toml
+++ b/crates/plugin-sdk/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "plugin-sdk"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+wasmtime = "20"
+anyhow = "1"

--- a/crates/plugin-sdk/src/lib.rs
+++ b/crates/plugin-sdk/src/lib.rs
@@ -1,0 +1,20 @@
+#![deny(clippy::all)]
+
+use anyhow::Result;
+use wasmtime::{Engine, Module, Store, Instance};
+
+pub struct WasmPlugin {
+    module: Module,
+}
+
+impl WasmPlugin {
+    pub fn new(engine: &Engine, wasm: &[u8]) -> Result<Self> {
+        let module = Module::from_binary(engine, wasm)?;
+        Ok(Self { module })
+    }
+
+    pub fn instantiate(&self, store: &mut Store<()>) -> Result<Instance> {
+        let instance = Instance::new(store, &self.module, &[])?;
+        Ok(instance)
+    }
+}

--- a/crates/plugin-sdk/tests/basic.rs
+++ b/crates/plugin-sdk/tests/basic.rs
@@ -1,0 +1,11 @@
+use plugin_sdk::WasmPlugin;
+use wasmtime::Engine;
+
+#[test]
+fn create_plugin() {
+    let engine = Engine::default();
+    let wasm: Vec<u8> = wasmtime::wat2wasm("(module)").unwrap();
+    let plugin = WasmPlugin::new(&engine, &wasm).unwrap();
+    let mut store = wasmtime::Store::new(&engine, ());
+    let _instance = plugin.instantiate(&mut store).unwrap();
+}

--- a/crates/terminal-core/Cargo.toml
+++ b/crates/terminal-core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "terminal-core"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+tokio = { version = "1.38", features = ["full"] }
+mio = "0.8"
+anyhow = "1"

--- a/crates/terminal-core/src/lib.rs
+++ b/crates/terminal-core/src/lib.rs
@@ -1,0 +1,34 @@
+#![deny(clippy::all)]
+
+use anyhow::Result;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::{Command};
+
+pub struct PseudoTerminal {
+    child: tokio::process::Child,
+}
+
+impl PseudoTerminal {
+    pub async fn spawn(shell: &str) -> Result<Self> {
+        let child = Command::new(shell)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .spawn()?;
+        Ok(Self { child })
+    }
+
+    pub async fn write(&mut self, bytes: &[u8]) -> Result<()> {
+        if let Some(stdin) = &mut self.child.stdin {
+            stdin.write_all(bytes).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn read(&mut self) -> Result<Vec<u8>> {
+        let mut buf = Vec::new();
+        if let Some(stdout) = &mut self.child.stdout {
+            stdout.read_to_end(&mut buf).await?;
+        }
+        Ok(buf)
+    }
+}

--- a/crates/terminal-core/tests/basic.rs
+++ b/crates/terminal-core/tests/basic.rs
@@ -1,0 +1,9 @@
+use terminal_core::PseudoTerminal;
+
+#[tokio::test]
+async fn spawn_echo() {
+    let mut pty = PseudoTerminal::spawn("/bin/echo").await.unwrap();
+    pty.write(b"hello\n").await.unwrap();
+    let out = pty.read().await.unwrap();
+    assert!(out.starts_with(b"hello"));
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Open Warp
+
+Open Warp is an open-source, Warp-style terminal written in Rust with a React/Tauri user interface. The project aims to run on Windows, macOS and Linux with feature parity across platforms.
+
+## Architecture
+
+```plantuml
+@startuml
+package "Crates" {
+  [terminal-core] --> [llm-client]
+  [terminal-core] --> [plugin-sdk]
+}
+package "Tauri App" {
+  [app]
+}
+@enduml
+```
+
+See `openwarp.toml` for configuration options.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cargo build --workspace


### PR DESCRIPTION
## Summary
- set up Cargo workspace for Open Warp
- add `terminal-core`, `llm-client`, and `plugin-sdk` crates
- document the architecture
- add build script and MIT license

## Testing
- `cargo test --workspace` *(fails: failed to download crates)*
- `pytest -q` *(fails: ModuleNotFoundError for RecordsClassifierGui dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684761797048832dbae0fa4649b47dad