### PR TITLE
Set ollama to CPU mode

### DIFF
--- a/RecordsClassifierGui/core/llm_engine.py
+++ b/RecordsClassifierGui/core/llm_engine.py
@@ -1,9 +1,12 @@
-"""
-core.llm_engine - LLM engine logic for Records Classifier
-"""
+"""core.llm_engine - LLM engine logic for Records Classifier"""
+
+import os
+
+# Force Ollama to run in CPU mode if possible. This avoids failures on machines
+# without compatible GPUs. The variable is ignored if already set by the user.
+os.environ.setdefault("OLLAMA_LLAMA_ACCELERATE", "false")
 
 import ollama
-import os
 import sys
 import time
 import datetime

--- a/run_classifier.ps1
+++ b/run_classifier.ps1
@@ -6,6 +6,7 @@
 $scriptPath = $PSScriptRoot
 Set-Location -Path $scriptPath
 $env:PYTHONPATH = $scriptPath
+$env:OLLAMA_LLAMA_ACCELERATE = 'false'
 
 # Check if Python is installed
 if (-not (Get-Command "python" -ErrorAction SilentlyContinue)) {


### PR DESCRIPTION
## Summary
- ensure Records Classifier always runs ollama in CPU mode
- configure Windows launcher to set `OLLAMA_LLAMA_ACCELERATE=false`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684762fe887c832dab2f702602b45c46