### PR TITLE
Refactor LLM pipeline

### DIFF
--- a/RecordsClassifierGui/logic/__init__.py
+++ b/RecordsClassifierGui/logic/__init__.py
@@ -6,8 +6,12 @@ This package contains the core business logic modules:
 - file_scanner: File discovery and filtering logic
 """
 
-from RecordsClassifierGui.classification_engine_fixed import ClassificationEngine, ClassificationResult, process_file
-from RecordsClassifierGui.file_scanner import FileScanner, INCLUDE_EXT, EXCLUDE_EXT
+from .classification_engine_fixed import (
+    ClassificationEngine,
+    ClassificationResult,
+    process_file,
+)
+from .file_scanner import FileScanner, INCLUDE_EXT, EXCLUDE_EXT
 
 __all__ = [
     'ClassificationEngine',


### PR DESCRIPTION
## Summary
- fix package imports for logic package
- rework `classification_engine_fixed` to always use the phi2 model
- add robust Ollama initialization and fallback heuristic
- enforce 300-word snippets and new cleanup policy prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847661348d0832d861fc3702783f8cb