### PR TITLE
Fix classification pipeline with HTTP-based LLM call

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,7 +7,12 @@ from dataclasses import dataclass
 from pathlib import Path
 import logging
 import os
-import yaml
+import json
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +46,11 @@ def load_config() -> AppConfig:
     if CONFIG_PATH.exists():
         try:
             with CONFIG_PATH.open("r", encoding="utf-8") as f:
-                data = yaml.safe_load(f) or {}
+                text = f.read()
+                if yaml:
+                    data = yaml.safe_load(text) or {}
+                else:
+                    data = json.loads(text or "{}")
         except Exception as exc:
             logger.warning("Failed to load %s: %s", CONFIG_PATH, exc)
             data = {}

--- a/run_app.py
+++ b/run_app.py
@@ -8,7 +8,31 @@ No dummy/test/stub code—this is the real deal.
 import logging
 import sys
 from pathlib import Path
-import requests
+import subprocess
+try:
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - fallback for minimal environments
+    import json as _json
+    from urllib import request as _urlreq
+
+    class _Resp:
+        def __init__(self, text: str):
+            self.text = text
+
+        def json(self):
+            return _json.loads(self.text)
+
+        def raise_for_status(self):
+            pass
+
+    class requests:  # type: ignore
+        @staticmethod
+        def post(url, json=None, headers=None, timeout=10):
+            data = _json.dumps(json or {}).encode()
+            req = _urlreq.Request(url, data=data, headers=headers or {}, method="POST")
+            with _urlreq.urlopen(req, timeout=timeout) as resp:
+                text = resp.read().decode()
+            return _Resp(text)
 from config import CONFIG
 
 def main():
@@ -27,6 +51,11 @@ def main():
 
     # Preload the model to avoid timeouts on first request
     try:
+        subprocess.run([
+            "ollama",
+            "run",
+            "pierce-county-records-classifier-phi2",
+        ], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         url = f"{CONFIG.ollama_url}/api/generate"
         requests.post(
             url,


### PR DESCRIPTION
## Summary
- switch classification engine to use Ollama HTTP API via `requests`
- validate model output and raise on malformed JSON
- preload model by running `ollama run` in `run_app`
- allow running without `requests` or `yaml` installed by providing lightweight fallbacks
- read entire file for classification rather than partial lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684779cac194832d96b30aa5dee5101b